### PR TITLE
fix: use `border-box` sizing on all elements

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -1,5 +1,9 @@
 @import url('https://fonts.googleapis.com/css2?family=Work+Sans:wght@300&display=swap');
 
+* {
+  box-sizing: border-box;
+}
+
 html, body {
   height: 100%;
   margin: 0;


### PR DESCRIPTION
This includes padding and borders in width calculations, which is more intuitive.