### PR TITLE
Improve lightbox styling

### DIFF
--- a/components/ClientScript.tsx
+++ b/components/ClientScript.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from "react";
+
+export type ClientScriptProps = {
+  fn: Function,
+  args?: string[],
+}
+
+export default function ClientScript(props: ClientScriptProps): ReactNode {
+  return (
+    <script children={`function __name(arg){return arg};(${props.fn})(${props.args?.join(", ") ?? ""})`} />
+  )
+}

--- a/components/Page.tsx
+++ b/components/Page.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import Link from "./Link";
+import ClientScript from "./ClientScript";
 
 export default function Page(props: {
   title: string;
@@ -24,26 +25,7 @@ export default function Page(props: {
           src={webAnalyticsSrc}
           data-website-id={webAnalyticsId}
         ></script>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-          document.addEventListener('DOMContentLoaded', function() {
-            const menuToggle = document.getElementById('mobile-menu');
-
-            window.addEventListener('hashchange', function() {
-              menuToggle.checked = false;
-            });
-
-            const anchorLinks = document.querySelectorAll('a[href^="/#"]');
-            anchorLinks.forEach(link => {
-              link.addEventListener('click', function() {
-                menuToggle.checked = false;
-              });
-            });
-          });
-          `,
-          }}
-        />
+        <ClientScript fn={initMenu} />
       </head>
 
       <body className="h-full margin-0 flex flex-col bg-sumiInk1 text-lighterYellow has-[#mobile-menu:checked]:overflow-hidden">
@@ -203,4 +185,24 @@ export default function Page(props: {
       </footer>
     </html>
   );
+}
+
+function initMenu (): void {
+  document.addEventListener('DOMContentLoaded', function() {
+    const menuToggle = document.getElementById('mobile-menu');
+    if (!(menuToggle instanceof HTMLInputElement)) {
+      throw new Error("Failed to initialise menu: couldn't find valid mobile-menu");
+    }
+
+    window.addEventListener('hashchange', function() {
+      menuToggle.checked = false;
+    });
+
+    const anchorLinks = document.querySelectorAll('a[href^="/#"]');
+    anchorLinks.forEach(link => {
+      link.addEventListener('click', function() {
+        menuToggle.checked = false;
+      });
+    });
+  });
 }

--- a/components/Thumbnail.tsx
+++ b/components/Thumbnail.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from "react";
+import ClientScript from "./ClientScript";
 
 export type ThumbnailProps = {
   alt: string;
@@ -38,17 +39,12 @@ export default function Thumbnail(props: ThumbnailProps): ReactNode {
           />
         </div>
       </dialog>
-      <script
-        children={`(${String(setupThumbnail)})(
-          window.thumbnails || (window.thumbnails = []),
-          ${JSON.stringify(props.src)},
-        )
-
-        /* Our String(...) trick above injects references to this unknown function. */
-        function __name(arg) {
-          return arg;
-        }
-        `}
+      <ClientScript
+        fn={setupThumbnail}
+        args={[
+          "window.thumbnails || (window.thumbnails = [])",
+          JSON.stringify(props.src),
+        ]}
       />
     </>
   );

--- a/components/Thumbnail.tsx
+++ b/components/Thumbnail.tsx
@@ -1,0 +1,132 @@
+import { ReactNode } from "react";
+
+export type ThumbnailProps = {
+  alt: string;
+  src: string;
+}
+
+export default function Thumbnail(props: ThumbnailProps): ReactNode {
+  return (
+    <>
+      <img
+        id={`${props.src}-thumb`}
+        alt={props.alt}
+        src={props.src}
+        className="h-[12rem] object-contain rounded-xl cursor-pointer"
+      />
+      <dialog
+        id={`${props.src}-dialog`}
+        className="inset-0 size-full max-h-full max-w-full bg-transparent backdrop-blur-sm open:flex items-center justify-center p-2 md:p-12"
+        /* @ts-ignore */
+        closedBy="any"
+      >
+        <div
+          id={`${props.src}-container`}
+          className="relative max-w-full max-h-full overflow-hidden rounded-lg bg-linkBlue text-right"
+        >
+          <a
+            id={`${props.src}-close`}
+            className="inline-block m-1 mr-2 p-1 rounded-sm cursor-pointer text-lighterYellow! hover:bg-waveBlue2!"
+          >
+            Close
+          </a>
+          <img
+            id={`${props.src}-img`}
+            alt={props.alt}
+            src={props.src}
+            className="max-w-full max-h-[calc(100vh-4rem)] md:max-h-[calc(100vh-8rem)] w-auto h-auto"
+          />
+        </div>
+      </dialog>
+      <script
+        children={`(${String(setupThumbnail)})(
+          window.thumbnails || (window.thumbnails = []),
+          ${JSON.stringify(props.src)},
+        )
+
+        /* Our String(...) trick above injects references to this unknown function. */
+        function __name(arg) {
+          return arg;
+        }
+        `}
+      />
+    </>
+  );
+}
+
+// This function isn't called inline, but is injected into the HTML.
+function setupThumbnail (items: string[], src: string) {
+  items.push(src);
+
+  const idx = items.length - 1;
+  let currentIdx = idx;
+
+  const thumb = document.getElementById(`${src}-thumb`);
+  const dialogEl = document.getElementById(`${src}-dialog`);
+  const container = document.getElementById(`${src}-container`);
+  const close = document.getElementById(`${src}-close`);
+  const imgEl = document.getElementById(`${src}-img`);
+
+  let dialog: HTMLDialogElement
+  if (dialogEl instanceof HTMLDialogElement) {
+    dialog = dialogEl;
+  } else {
+    throw new Error(`Unable to configure thumbnail for src=${src}: couldn't find ${src}-dialog`)
+  }
+
+  let img: HTMLImageElement
+  if (imgEl instanceof HTMLImageElement) {
+    img = imgEl;
+  } else {
+    throw new Error(`Unable to configure thumbnail for src=${src}: couldn't find ${src}-img`)
+  }
+
+  thumb.addEventListener("click", () => {
+    dialog.showModal();
+    document.body.classList.add("overflow-hidden");
+    document.addEventListener("keydown", onKeydown);
+  });
+
+  close.addEventListener("click", (e) => {
+    e.preventDefault();
+    dialog.close();
+  })
+
+  dialog.addEventListener("click", () => {
+    dialog.close();
+  });
+
+  container.addEventListener("click", (e) => {
+    e.stopPropagation();
+  });
+
+  dialog.addEventListener("cancel", () => {
+    onClose();
+  });
+
+  dialog.addEventListener("close", () => {
+    onClose();
+  });
+
+  function onClose () {
+    currentIdx = idx;
+    img.src = items[idx];
+    document.body.classList.remove("overflow-hidden");
+    document.removeEventListener("keydown", onKeydown);
+  }
+
+  function onKeydown (e: KeyboardEvent) {
+    switch (e.key) {
+      case "ArrowLeft":
+        if (currentIdx > 0) {
+          img.src = items[--currentIdx];
+        }
+        break
+      case "ArrowRight":
+        if (currentIdx < items.length - 1) {
+          img.src = items[++currentIdx];
+        }
+        break
+    }
+  }
+}

--- a/content/index.11ty.tsx
+++ b/content/index.11ty.tsx
@@ -273,24 +273,25 @@ function Screenshot(props: {
       />
       <dialog
         id={`${props.screenshot.src}-dialog`}
-        className="fixed left-1/2 top-1/2 translate-[-50%] max-w-full size-max md:max-h-[calc(100%-24*var(--spacing))] md:max-w-[calc(100%-24*var(--spacing))] backdrop:backdrop-blur-sm bg-linkBlue border-4 md:border-8 rounded-lg md:rounded-xl border-linkBlue outline-0 open:flex flex-col"
+        className="inset-0 size-full max-h-full max-w-full bg-transparent backdrop-blur-sm open:flex items-center justify-center p-2 md:p-12"
         /* @ts-ignore */
         closedBy="any"
       >
-        <div className="flex justify-end bg-linkBlue pb-[8px] pr-[8px]">
+        <div
+          id={`${props.screenshot.src}-container`}
+          className="relative max-w-full max-h-full overflow-hidden rounded-lg bg-linkBlue text-right"
+        >
           <a
             id={`${props.screenshot.src}-close`}
-            className="p-1 rounded-sm cursor-pointer text-lighterYellow! hover:bg-waveBlue2!"
+            className="inline-block m-1 mr-2 p-1 rounded-sm cursor-pointer text-lighterYellow! hover:bg-waveBlue2!"
           >
             Close
           </a>
-        </div>
-        <div id={`${props.screenshot.src}-scroll`} className="overflow-y-auto">
           <img
             id={`${props.screenshot.src}-img`}
             alt={props.screenshot.alt}
             src={props.screenshot.src}
-            className="object-contain rounded-sm"
+            className="max-w-full max-h-[calc(100vh-4rem)] md:max-h-[calc(100vh-8rem)] w-auto h-auto"
           />
         </div>
       </dialog>
@@ -303,8 +304,8 @@ function Screenshot(props: {
 
           const thumb = document.getElementById(\`\${id}-thumb\`);
           const dialog = document.getElementById(\`\${id}-dialog\`);
+          const container = document.getElementById(\`\${id}-container\`);
           const close = document.getElementById(\`\${id}-close\`);
-          const scroll = document.getElementById(\`\${id}-scroll\`);
           const img = document.getElementById(\`\${id}-img\`);
 
           thumb.addEventListener("click", () => {
@@ -317,6 +318,14 @@ function Screenshot(props: {
             e.preventDefault();
             dialog.close();
           })
+
+          dialog.addEventListener("click", () => {
+            dialog.close();
+          });
+
+          container.addEventListener("click", (e) => {
+            e.stopPropagation();
+          });
 
           dialog.addEventListener("cancel", () => {
             onClose();
@@ -338,13 +347,11 @@ function Screenshot(props: {
               case 37:
                 if (currentIdx > 0) {
                   img.src = window.screenshots[--currentIdx];
-                  scroll.scrollTop = 0;
                 }
                 break
               case 39:
                 if (currentIdx < window.screenshots.length - 1) {
                   img.src = window.screenshots[++currentIdx];
-                  scroll.scrollTop = 0;
                 }
                 break
             }

--- a/content/index.11ty.tsx
+++ b/content/index.11ty.tsx
@@ -5,6 +5,7 @@ import Section from "../components/Section";
 import Container from "../components/Container";
 import Link from "../components/Link";
 import Heading from "../components/Heading";
+import Thumbnail, { ThumbnailProps } from "../components/Thumbnail";
 
 export default function Home(): ReactNode {
   return (
@@ -217,15 +218,10 @@ function Member(props: {
   );
 }
 
-type Screenshot = {
-  alt: string;
-  src: string;
-}
-
 function Example(props: {
   title: string;
   href?: string;
-  screenshots: Screenshot[];
+  screenshots: ThumbnailProps[];
   description: ReactNode;
   stack: string;
   testimonial?: string;
@@ -249,7 +245,7 @@ function Example(props: {
           )
       }
       <div className="flex flex-row flex-wrap gap-4 items-center">
-        {props.screenshots.map(s => <Screenshot screenshot={s} />)}
+        {props.screenshots.map(t => <Thumbnail {...t} />)}
       </div>
       <p>{props.description}</p>
       <p>{props.stack}</p>
@@ -257,107 +253,5 @@ function Example(props: {
         <q className="italic">{props.testimonial}</q>
       )}
     </div>
-  );
-}
-
-function Screenshot(props: {
-  screenshot: Screenshot;
-}): ReactNode {
-  return (
-    <>
-      <img
-        id={`${props.screenshot.src}-thumb`}
-        alt={props.screenshot.alt}
-        src={props.screenshot.src}
-        className="h-[12rem] object-contain rounded-xl cursor-pointer"
-      />
-      <dialog
-        id={`${props.screenshot.src}-dialog`}
-        className="inset-0 size-full max-h-full max-w-full bg-transparent backdrop-blur-sm open:flex items-center justify-center p-2 md:p-12"
-        /* @ts-ignore */
-        closedBy="any"
-      >
-        <div
-          id={`${props.screenshot.src}-container`}
-          className="relative max-w-full max-h-full overflow-hidden rounded-lg bg-linkBlue text-right"
-        >
-          <a
-            id={`${props.screenshot.src}-close`}
-            className="inline-block m-1 mr-2 p-1 rounded-sm cursor-pointer text-lighterYellow! hover:bg-waveBlue2!"
-          >
-            Close
-          </a>
-          <img
-            id={`${props.screenshot.src}-img`}
-            alt={props.screenshot.alt}
-            src={props.screenshot.src}
-            className="max-w-full max-h-[calc(100vh-4rem)] md:max-h-[calc(100vh-8rem)] w-auto h-auto"
-          />
-        </div>
-      </dialog>
-      <script
-        children={`((id) => {
-          window.screenshots = window.screenshots || [];
-          window.screenshots.push(id);
-          const idx = window.screenshots.length - 1;
-          let currentIdx = idx;
-
-          const thumb = document.getElementById(\`\${id}-thumb\`);
-          const dialog = document.getElementById(\`\${id}-dialog\`);
-          const container = document.getElementById(\`\${id}-container\`);
-          const close = document.getElementById(\`\${id}-close\`);
-          const img = document.getElementById(\`\${id}-img\`);
-
-          thumb.addEventListener("click", () => {
-            dialog.showModal();
-            document.body.classList.add("overflow-hidden");
-            document.addEventListener("keydown", onKeydown);
-          });
-
-          close.addEventListener("click", (e) => {
-            e.preventDefault();
-            dialog.close();
-          })
-
-          dialog.addEventListener("click", () => {
-            dialog.close();
-          });
-
-          container.addEventListener("click", (e) => {
-            e.stopPropagation();
-          });
-
-          dialog.addEventListener("cancel", () => {
-            onClose();
-          });
-
-          dialog.addEventListener("close", () => {
-            onClose();
-          });
-
-          function onClose () {
-            currentIdx = idx;
-            img.src = window.screenshots[idx];
-            document.body.classList.remove("overflow-hidden");
-            document.removeEventListener("keydown", onKeydown);
-          }
-
-          function onKeydown (e) {
-            switch (e.keyCode) {
-              case 37:
-                if (currentIdx > 0) {
-                  img.src = window.screenshots[--currentIdx];
-                }
-                break
-              case 39:
-                if (currentIdx < window.screenshots.length - 1) {
-                  img.src = window.screenshots[++currentIdx];
-                }
-                break
-            }
-          }
-        })(${JSON.stringify(props.screenshot.src)})`}
-      />
-    </>
   );
 }


### PR DESCRIPTION
- bc47678 **refactor: improve lightbox styling**


- df05d1c **refactor: create `Thumbnail` component from index `Screenshot`**

  This lets us reuse it easily in other pages.
  
  In the process, the inline `<script>` content was mostly pulled into a
  separate function, which is then injected into the `<script>` via
  `Function.prototype.toString`. This means the code for the `<script>`
  benefits from linting, type-checking, formatting, etc.
  
  This mostly works with the exception of a weird `__name(...)` function
  that shows up in the result. To work around that, a no-op `__name(...)`
  function is also defined in the `<script>` tag.

- 5ae028a **refactor: wrap up the client script hack into a component**

  This lets us inject functions from the source in the client HTML.
