### PR TITLE
Switch to containerised deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,67 @@
+name: deploy
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: The environment to target for the deployment
+        type: string
+        required: true
+    secrets:
+      KUBECONFIG:
+        required: true
+      REGISTRY_PASSWORD:
+        required: true
+
+env:
+  REGISTRY: registry.${{ vars.RUNTIME_DOMAIN }}
+  IMAGE: ${{ vars.SERVICE }}:${{ inputs.environment }}-${{ github.sha }}
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - run: npm install
+      - run: npm run build
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ vars.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment: ${{ inputs.environment }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write kubeconfig
+        run: echo "$KUBECONFIG" > "$RUNNER_TEMP/kubeconfig"
+        env:
+          KUBECONFIG: ${{ secrets.KUBECONFIG }}
+
+      - run: ./deploy.sh ${{ inputs.environment }}
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+          KUBECONFIG: ${{ runner.temp }}/kubeconfig
+          MANAGED_DOMAIN: ${{ vars.SERVICE }}-${{ inputs.environment }}.${{ vars.RUNTIME_DOMAIN }}
+          SERVICE: ${{ vars.SERVICE }}
+          VANITY_DOMAIN: ${{ vars.VANITY_DOMAIN }}
+          WEB_ANALYTICS_SRC: ${{ vars.WEB_ANALYTICS_SRC }}
+          WEB_ANALYTICS_ID: ${{ vars.WEB_ANALYTICS_ID }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,16 @@
+name: main
+
+on:
+  push:
+    branches:
+      - containerise
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy.yaml
+    with:
+      environment: dev
+    secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM busybox:1.37.0
+
+RUN adduser -D static
+USER static
+WORKDIR /home/static
+
+COPY _site .
+
+CMD ["busybox", "httpd", "-f", "-v", "-p", "3000"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function usage {
+  echo "Usage: $0 <env>" >&2
+  exit 1
+}
+
+[[ $# -ge 1 ]] || usage
+environment=$1
+shift
+
+echo "Deploying $SERVICE-$environment... " >&2
+echo >&2
+
+export NAMESPACE="$SERVICE-${environment}"
+
+WEB_ANALYTICS_SRC_BASE64="$(echo -n "$WEB_ANALYTICS_SRC" | openssl base64 -A)"
+WEB_ANALYTICS_ID_BASE64="$(echo -n "$WEB_ANALYTICS_ID" | openssl base64 -A)"
+export WEB_ANALYTICS_SRC_BASE64 WEB_ANALYTICS_ID_BASE64
+
+# shellcheck disable=SC2016
+variables='
+  $IMAGE
+  $MANAGED_DOMAIN
+  $NAMESPACE
+  $SERVICE
+  $VANITY_DOMAIN
+  $WEB_ANALYTICS_ID_BASE64
+  $WEB_ANALYTICS_SRC_BASE64
+  '
+
+envsubst "$variables" <kubernetes.yaml | kubectl apply -f -
+
+echo >&2
+echo 'Deployment complete' >&2

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $NAMESPACE
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: $SERVICE
+  namespace: $NAMESPACE
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: $SERVICE
+    app.kubernetes.io/part-of: $SERVICE
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+      protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: $SERVICE
+  namespace: $NAMESPACE
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    acme.cert-manager.io/http01-edit-in-place: "true"
+spec:
+  tls:
+    - hosts:
+        - $MANAGED_DOMAIN
+      secretName: $SERVICE-tls-certificate
+    - hosts:
+        - $VANITY_DOMAIN
+      secretName: $SERVICE-vanity-tls-certificate
+  rules:
+    - host: $MANAGED_DOMAIN
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: $SERVICE
+                port:
+                  number: 80
+    - host: $VANITY_DOMAIN
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: $SERVICE
+                port:
+                  number: 80
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: web-analytics
+  namespace: $NAMESPACE
+  labels:
+    app.kubernetes.io/part-of: $SERVICE
+data:
+  src: "$WEB_ANALYTICS_SRC_BASE64"
+  id: "$WEB_ANALYTICS_ID_BASE64"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: $SERVICE
+  namespace: $NAMESPACE
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: $SERVICE
+      app.kubernetes.io/part-of: $SERVICE
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: $SERVICE
+        app.kubernetes.io/part-of: $SERVICE
+    spec:
+      restartPolicy: Always
+      containers:
+        - name: $SERVICE
+          image: $IMAGE
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+          env:
+            - name: WEB_ANALYTICS_SRC
+              valueFrom:
+                secretKeyRef:
+                  name: web-analytics
+                  key: src
+            - name: WEB_ANALYTICS_ID
+              valueFrom:
+                secretKeyRef:
+                  name: web-analytics
+                  key: id


### PR DESCRIPTION
- c0347d2 **chore: switch to containerised deployment**

  Having migrated our DNS from AWS, we now realise that CloudFront (hence
  Amplify) doesn't support custom domains outside of AWS (since they don't
  advertise stable IPs and root domain's can't be CNAMEs). In the spirit of
  not going back to AWS, we're migrating the site into a container (we
  already run a few semi-static sites on containers and it works fine).
